### PR TITLE
Add backend validation for publish guard

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1242,7 +1242,7 @@ class Custom_Status extends Module {
 
 		$post = get_post( $postarr['ID'] );
 
-		// if post is already published then we don't need to check for custom statuses
+		// if post is already published and being updated then we don't need to check for custom statuses
 		if ( 'publish' === $post->post_status ) {
 			return $maybe_empty;
 		}


### PR DESCRIPTION
## Description

This PR adds backend PHP validation for the new publish guard feature. I.e.: you cannot publish a post that is not at the last custom status.

## Steps to Test

1. Check out PR.
2. Comment out the [following lines](https://github.com/Automattic/vip-workflow-plugin/blob/3564304be824a409c22559386d8b2de0bb754e01/modules/custom-status/lib/custom-status-block.js#L50-L59) to bypass the JS publish block.
3. Try to publish a post that is not at `Pending review` status.
4. Verify that publish failed with proper error message.
