### PR TITLE
Add HMR section to README, re-add dotenv support for webpack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ Ensure that the dev environment has already been started with `wp-env start`.
 
 1. Integration test: `composer run integration`
 2. Multi-site integration test: `composer run integration-ms`
+
+### Using Hot Module Replacement
+
+React hot reloading is supported. A few configuration steps are required for the setup:
+
+1. Set `define( 'SCRIPT_DEBUG', true );` in your `wp-config.php` or `vip-config.php`. At the time of writing, this is [a `wp-scripts` limitation](https://github.com/WordPress/gutenberg/blob/9e07a75/packages/scripts/README.md?plain=1#L390).
+2. Run `npm run dev:hot`. If you're running WordPress on a non-localhost hostname, e.g. on `vip dev-env`, you may also need to specify the hostname:
+
+    ```bash
+    HOST=mysite.vipdev.lndo.site npm run dev:hot
+    ```
+
+    This can also be specified using a `.env` configuration file:
+
+    ```
+    HOST=mysite.vipdev.lndo.site
+    ```
+
+    If you use `wp-env`, you should be able to skip specifying `HOST` manually.
+
+3. If HMR is not working and you're developing out of a new component tree, you may also need to opt-in to hot module reloading via [`module.hot.accept()`](https://github.com/Automattic/vip-workflow-plugin/blob/e058354/modules/custom-status/lib/custom-status-configure.js#L19-L21)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const defaultScriptsConfig = require( '@wordpress/scripts/config/webpack.config' );
 const glob = require( 'glob' );
+require( 'dotenv' ).config();
 
 const wpScriptsModules = [ 'custom-status' ];
 const wpScriptsModulesGlob =


### PR DESCRIPTION
## Description

React hot module support was added in https://github.com/Automattic/vip-workflow-plugin/pull/5 and documented in that issue, but nowhere else. This PR adds a section to the README explaining how to enable this feature, as well as adding `.env` support for an HMR-related environment variable.

## Steps to Test

1. Follow the instructions in the README. The `module.hot.accept()` step will not be necessary for testing, as [this is already enabled](https://github.com/Automattic/vip-workflow-plugin/blob/e058354b81c71d9c9df05c8d194014e54895f138/modules/custom-status/lib/custom-status-configure.js#L19-L21) for the workflow manager.
2. After running `npm run dev:hot` (and setting a `HOST` if necessary), load the workflow manager page under Admin -> VIP Workflow -> Custom Statuses. Ensure you've disabled cache or done a hard refresh of the page.
3. Check that you see a successful connection to the server in the browser console. See the video below for an example.
4. Change some JavaScript in the workflow manager, for example the "Create" text label in `modules/custom-status/lib/components/workflow-manager.js`
5. Save in the editor, and see the JS on the page change:

https://github.com/user-attachments/assets/e1575e4b-e31f-4e32-a354-ab59972661bb