### PR TITLE
Update blueprint to generalize URL, landing page

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-  "landingPage": "/wp-admin/admin.php?page=vw-custom-status-settings",
+  "landingPage": "/wp-admin/admin.php?page=vw-custom-status",
   "preferredVersions": {
     "php": "8.0",
     "wp": "latest"
@@ -14,7 +14,7 @@
       "step": "installPlugin",
       "pluginZipFile": {
         "resource": "url",
-        "url": "https://github-proxy.com/proxy/?repo=Automattic/vip-workflow-plugin&release=0.1.0&asset=vip-workflow-0.1.0.zip"
+        "url": "https://github-proxy.com/proxy/?repo=Automattic/vip-workflow-plugin"
       },
       "options": {
         "activate": true


### PR DESCRIPTION
## Description

Two small changes:

1. Fixed landing page URL, which pointed to a no longer used page slug.
2. Updated `pluginZipFile.url` to point to the repository instead of a particular release. Makes sharing updates more flexible, and we don't need to explicitly PR to update `blueprint.json` to test new features using the blueprint URL.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Go to https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/vip-workflow-plugin/fix/blueprint-landing-and-url/blueprint.json.
2. See 

    ![Workflow configuration dashboard](https://github.com/user-attachments/assets/e5086ad4-e3e5-4956-9419-30bd8a3c5efb)
