### PR TITLE
Fix PHP8 pass-by-reference error

### DIFF
--- a/modules/preview/preview.php
+++ b/modules/preview/preview.php
@@ -83,7 +83,7 @@ class Preview extends Module {
 		return $query_vars;
 	}
 
-	public function allow_preview_result( $posts, &$query ) {
+	public function allow_preview_result( $posts, $query ) {
 		$token = $query->query_vars['vw-token'] ?? false;
 
 		// If there's no token, go back to result processing quickly


### PR DESCRIPTION
## Description

Viewing preview links generated this warning in logs:

```
PHP Warning:  VIPWorkflow\Modules\Preview::allow_preview_result(): Argument #2 ($query) must be passed by reference, value given in /wp/wp-includes/class-wp-hook.php on line 324
```

This is a little odd, because the filter we hook:

https://github.com/Automattic/vip-workflow-plugin/blob/b2b8c825eb8c9ef598d080889132f25533a3fce8/modules/preview/preview.php#L47

actually does provide the second parameter by reference:

https://github.com/Automattic/vip-workflow-plugin/blob/b2b8c825eb8c9ef598d080889132f25533a3fce8/modules/preview/preview.php#L86

This appears to follow the way that the filter is [invoked by core](https://github.com/WordPress/WordPress/blob/741a7869fd77a0f979a2116ae87b1413a0e62fb1/wp-includes/class-wp-query.php#L3393-L3401).

From a quick look at results for this error, it appears to be a PHP8 change that made function callbacks more restrictive about reference types. The issue was solved by removing the `&` reference. We don't actually mutate the `$query` reference anyway, and this removes the warning. I'm not sure what the correct way would be to receive the second parameter by reference, but in this case we don't need it.

## Steps to Test

1. On `trunk`, start tailing site logs.
2. Generate a preview link.
3. View the preview link on a non-logged-in browser. See that the link works, but an error is shown in logs:

    ```
    PHP Warning:  VIPWorkflow\Modules\Preview::allow_preview_result(): Argument #2 ($query) must be passed by reference, value given in /wp/wp-includes/class-wp-hook.php on line 324
    ````

4. Update the branch to `fix/preview-php-error`
5. Refresh the preview link in the browser, or if it was a one time link generate and view a second link.
6. See that the link works, but the error is no longer present.
