### PR TITLE
Refactor Preview module as static module

### DIFF
--- a/class-workflow.php
+++ b/class-workflow.php
@@ -75,12 +75,14 @@ class VIP_Workflow {
 		// VIP Workflow base module
 		require_once VIP_WORKFLOW_ROOT . '/modules/shared/php/class-module.php';
 
+		$skip_module_dirs = [ 'shared', 'preview' ];
+
 		// Scan the modules directory and include any modules that exist there
 		$module_dirs = scandir( VIP_WORKFLOW_ROOT . '/modules/' );
 		$class_names = [];
 		foreach ( $module_dirs as $module_dir ) {
 			// Skip the . and .. directories, as well as the shared folder
-			if ( file_exists( VIP_WORKFLOW_ROOT . "/modules/{$module_dir}/$module_dir.php" ) && 'shared' !== $module_dir ) {
+			if ( file_exists( VIP_WORKFLOW_ROOT . "/modules/{$module_dir}/$module_dir.php" ) && ! in_array( $module_dir, $skip_module_dirs ) ) {
 				include_once VIP_WORKFLOW_ROOT . "/modules/{$module_dir}/$module_dir.php";
 
 				// Prepare the class name because it should be standardized

--- a/modules/preview/preview.php
+++ b/modules/preview/preview.php
@@ -130,7 +130,12 @@ class Preview {
 	// Public API
 
 	/**
-	 * Get the expiration options available in the preview modal dropdown.
+	 * Returns the valid set of expiration options for preview links. See the
+	 * vw_preview_expiration_options filter for customization.
+	 *
+	 * @access public
+	 *
+	 * @return array
 	 */
 	public static function get_link_expiration_options(): array {
 		/**

--- a/modules/preview/preview.php
+++ b/modules/preview/preview.php
@@ -12,42 +12,30 @@ require_once __DIR__ . '/rest/preview-endpoint.php';
 
 use VIPWorkflow\Modules\Preview\PreviewEndpoint;
 use VIPWorkflow\VIP_Workflow;
-use VIPWorkflow\Modules\Shared\PHP\Module;
 use VIPWorkflow\Modules\Preview\Token;
+use WP_Query;
 
-class Preview extends Module {
-	public $module;
-
-	public function __construct() {
-		// Register the module with VIP Workflow
-		$this->module_url = $this->get_module_url( __FILE__ );
-
-		$this->module = VIP_Workflow::instance()->register_module( 'preview', [
-			'title'      => __( 'Preview Link', 'vip-workflow' ),
-			'module_url' => $this->module_url,
-			'slug'       => 'preview',
-			'autoload'   => true,
-		] );
-	}
-
+class Preview {
 	/**
 	 * Initialize preview module
 	 */
-	public function init() {
+	public static function init(): void {
 		PreviewEndpoint::init();
 
 		// Load block editor JS
-		add_action( 'enqueue_block_editor_assets', [ $this, 'load_block_editor_scripts' ], 9 /* Load before custom status module */ );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'load_block_editor_scripts' ], 9 /* Load before custom status module */ );
 
 		// Load block editor CSS
-		add_action( 'enqueue_block_editor_assets', [ $this, 'load_block_editor_styles' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'load_block_editor_styles' ] );
 
 		// Preview rendering
-		add_filter( 'query_vars', [ $this, 'add_preview_query_vars' ] );
-		add_action( 'posts_results', [ $this, 'allow_preview_result' ], 10, 2 );
+		add_filter( 'query_vars', [ __CLASS__, 'add_preview_query_vars' ] );
+		add_action( 'posts_results', [ __CLASS__, 'allow_preview_result' ], 10, 2 );
 	}
 
-	public function load_block_editor_scripts() {
+	// Block editor asset filters
+
+	public static function load_block_editor_scripts(): void {
 		$asset_file = include VIP_WORKFLOW_ROOT . '/dist/modules/preview/preview.asset.php';
 		wp_enqueue_script( 'vip-workflow-preview-script', VIP_WORKFLOW_URL . 'dist/modules/preview/preview.js', $asset_file['dependencies'], $asset_file['version'], true );
 
@@ -65,25 +53,28 @@ class Preview extends Module {
 		wp_localize_script( 'vip-workflow-preview-script', 'VW_PREVIEW', [
 			'custom_post_types'    => $custom_post_types,
 			'custom_status_slugs'  => $custom_status_slugs,
-			'expiration_options'   => $this->get_link_expiration_options(),
+			'expiration_options'   => self::get_link_expiration_options(),
 			'text_preview_error'   => __( 'There was an error generating a preview link:', 'vip-workflow' ),
 			'url_generate_preview' => $generate_preview_url,
 		] );
 	}
 
-	public function load_block_editor_styles() {
+	public static function load_block_editor_styles(): void {
 		$asset_file = include VIP_WORKFLOW_ROOT . '/dist/modules/preview/preview.asset.php';
 
 		wp_enqueue_style( 'vip-workflow-preview-styles', VIP_WORKFLOW_URL . 'dist/modules/preview/preview.css', [ 'wp-components' ], $asset_file['version'] );
 	}
 
-	public function add_preview_query_vars( $query_vars ) {
+	// Preview rendering WP_Query filters
+
+	public static function add_preview_query_vars( array $query_vars ) {
+		// Allow 'vw-token' GET parameter to be detected in WP_Query parameters
 		$query_vars[] = 'vw-token';
 
 		return $query_vars;
 	}
 
-	public function allow_preview_result( $posts, $query ) {
+	public static function allow_preview_result( array $posts, WP_Query $query ) {
 		$token = $query->query_vars['vw-token'] ?? false;
 
 		// If there's no token, go back to result processing quickly
@@ -136,10 +127,12 @@ class Preview extends Module {
 		return $posts;
 	}
 
+	// Public API
+
 	/**
 	 * Get the expiration options available in the preview modal dropdown.
 	 */
-	public function get_link_expiration_options() {
+	public static function get_link_expiration_options(): array {
 		/**
 		 * Filter the expiration options available in the preview modal dropdown.
 		 *
@@ -169,3 +162,5 @@ class Preview extends Module {
 		]);
 	}
 }
+
+Preview::init();

--- a/modules/preview/rest/preview-endpoint.php
+++ b/modules/preview/rest/preview-endpoint.php
@@ -8,6 +8,7 @@
 namespace VIPWorkflow\Modules\Preview;
 
 use VIPWorkflow\VIP_Workflow;
+use VIPWorkflow\Modules\Preview;
 use WP_Error;
 use WP_REST_Request;
 
@@ -46,7 +47,7 @@ class PreviewEndpoint {
 				'expiration'      => [
 					'required'          => true,
 					'validate_callback' => function ( $param ) {
-						$expiration_options = VIP_Workflow::instance()->preview->get_link_expiration_options();
+						$expiration_options = Preview::get_link_expiration_options();
 						$expiration_values  = wp_list_pluck( $expiration_options, 'value' );
 
 						return in_array( $param, $expiration_values );
@@ -142,7 +143,7 @@ class PreviewEndpoint {
 	 * @return int|WP_Error The number of seconds that the expiration represents or a WP_Error if the value is invalid.
 	 */
 	private static function get_expiration_seconds( $expiration_value ) {
-		$expiration_options         = VIP_Workflow::instance()->preview->get_link_expiration_options();
+		$expiration_options         = Preview::get_link_expiration_options();
 		$selected_expiration_option = array_values( array_filter( $expiration_options, function ( $option ) use ( $expiration_value ) {
 			return $option['value'] === $expiration_value;
 		} ) );

--- a/vip-workflow.php
+++ b/vip-workflow.php
@@ -16,28 +16,34 @@
 
 namespace VIPWorkflow;
 
-if ( ! defined( 'VIP_WORKFLOW_LOADED' ) ) {
-	define( 'VIP_WORKFLOW_LOADED', true );
-
-	// ToDo: Add a check for the WP version as well.
-	// ToDo: When 6.4 is our min version, switch to wp_admin_notice.
-	if ( version_compare( phpversion(), '8.0', '<' ) ) {
-		add_action( 'admin_notices', function () {
-			?>
-			<div class="notice notice-error">
-					<p><?php esc_html_e( 'VIP Workflow requires PHP 8.0+.', 'vip-workflow' ); ?></p>
-				</div>
-			<?php
-		}, 10, 0 );
-		return;
-	}
-
-	// Define contants
-	define( 'VIP_WORKFLOW_VERSION', '0.2.0' );
-	define( 'VIP_WORKFLOW_ROOT', __DIR__ );
-	define( 'VIP_WORKFLOW_URL', plugins_url( '/', __FILE__ ) );
-	define( 'VIP_WORKFLOW_SETTINGS_PAGE', add_query_arg( 'page', 'vw-settings', get_admin_url( null, 'admin.php' ) ) );
-	define( 'VIP_WORKFLOW_REST_NAMESPACE', 'vip-workflow/v1' );
-
-	require_once VIP_WORKFLOW_ROOT . '/class-workflow.php';
+if ( defined( 'VIP_WORKFLOW_LOADED' ) ) {
+	return;
 }
+
+define( 'VIP_WORKFLOW_LOADED', true );
+
+// ToDo: Add a check for the WP version as well.
+// ToDo: When 6.4 is our min version, switch to wp_admin_notice.
+if ( version_compare( phpversion(), '8.0', '<' ) ) {
+	add_action( 'admin_notices', function () {
+		?>
+		<div class="notice notice-error">
+				<p><?php esc_html_e( 'VIP Workflow requires PHP 8.0+.', 'vip-workflow' ); ?></p>
+			</div>
+		<?php
+	}, 10, 0 );
+	return;
+}
+
+// Define contants
+define( 'VIP_WORKFLOW_VERSION', '0.2.0' );
+define( 'VIP_WORKFLOW_ROOT', __DIR__ );
+define( 'VIP_WORKFLOW_URL', plugins_url( '/', __FILE__ ) );
+define( 'VIP_WORKFLOW_SETTINGS_PAGE', add_query_arg( 'page', 'vw-settings', get_admin_url( null, 'admin.php' ) ) );
+define( 'VIP_WORKFLOW_REST_NAMESPACE', 'vip-workflow/v1' );
+
+// Main plugin class
+require_once VIP_WORKFLOW_ROOT . '/class-workflow.php';
+
+// Modules
+require_once VIP_WORKFLOW_ROOT . '/modules/preview/preview.php';


### PR DESCRIPTION
## Description

The original plan was to remove the module system from the entire codebase. I've since scaled this back to one of the newer modules (Preview) to demonstrate the basics. We can build on this system with other modules and remove the entire module system loader once the other modules has been migrated.

## Steps to Test

1. Check out PR.
2. Ensure generating and previewing links continue to work as designed.

## Other notes

I'll leave some notes in code below describing the basic structure a little better. This isn't directly documented in code, as the structure will be more easy to follow and self-evident once we've moved additional modules to match.