### PR TITLE
Refactor the notifications module

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Static analysis
-on:
-  pull_request:
-  push:
-    branches:
-      - trunk
+
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/class-workflow.php
+++ b/class-workflow.php
@@ -75,7 +75,7 @@ class VIP_Workflow {
 		// VIP Workflow base module
 		require_once VIP_WORKFLOW_ROOT . '/modules/shared/php/class-module.php';
 
-		$skip_module_dirs = [ 'shared', 'preview' ];
+		$skip_module_dirs = [ 'shared', 'preview', 'notifications', 'editorial-metadata' ];
 
 		// Scan the modules directory and include any modules that exist there
 		$module_dirs = scandir( VIP_WORKFLOW_ROOT . '/modules/' );

--- a/modules/editorial-metadata/rest/editorial-metadata-endpoint.php
+++ b/modules/editorial-metadata/rest/editorial-metadata-endpoint.php
@@ -7,7 +7,6 @@
 namespace VIPWorkflow\Modules\EditorialMetadata\REST;
 
 use VIPWorkflow\Modules\EditorialMetadata;
-use VIPWorkflow\VIP_Workflow;
 use WP_Error;
 use WP_REST_Request;
 use WP_Term;
@@ -137,8 +136,6 @@ class EditorialMetadataEndpoint {
 		$editorial_metadata_slug        = sanitize_title( $request->get_param( 'name' ) );
 		$editorial_metadata_description = $request->get_param( 'description' );
 		$editorial_metadata_type         = $request->get_param( 'type' );
-
-		$editorial_metadata_module = VIP_Workflow::instance()->editorial_metadata;
 
 		// Check that the name isn't numeric
 		if ( is_numeric( $editorial_metadata_name ) ) {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -6,9 +6,10 @@
  */
 namespace VIPWorkflow\Modules;
 
+use WP_Post;
+
 use VIPWorkflow\VIP_Workflow;
 use function VIPWorkflow\Modules\Shared\PHP\vw_draft_or_post_title;
-use WP_Post;
 
 class Notifications {
 

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -8,6 +8,7 @@ namespace VIPWorkflow\Modules;
 
 use VIPWorkflow\VIP_Workflow;
 use function VIPWorkflow\Modules\Shared\PHP\vw_draft_or_post_title;
+use WP_Post;
 
 class Notifications {
 
@@ -28,7 +29,7 @@ class Notifications {
 	/**
 	 * Set up and send post status change notification email
 	 */
-	public static function notification_status_change( string $new_status, string $old_status, \WP_Post $post ): void {
+	public static function notification_status_change( string $new_status, string $old_status, WP_Post $post ): void {
 		$supported_post_types = VIP_Workflow::instance()->get_supported_post_types();
 		if ( ! in_array( $post->post_type, $supported_post_types ) ) {
 			return;
@@ -53,6 +54,7 @@ class Notifications {
 			$post_id    = $post->ID;
 			$post_title = vw_draft_or_post_title( $post_id );
 			$post_type  = $post->post_type;
+			$subject_post_type = ucfirst( $post_type );
 
 			if ( 0 != $current_user->ID ) {
 				$current_user_display_name = $current_user->display_name;
@@ -89,37 +91,37 @@ class Notifications {
 			if ( 'new' == $old_status || 'auto-draft' == $old_status ) {
 				$old_status_friendly_name = 'New';
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] New %2$s Created: "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] New %2$s Created: "%3$s"', 'vip-workflow' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( 'A new %1$s (#%2$s "%3$s") was created by %4$s %5$s.', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user->display_name, $current_user->user_email ) . "\r\n";
 			} elseif ( 'trash' == $new_status ) {
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Trashed: "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] %2$s Trashed: "%3$s"', 'vip-workflow' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( '%1$s #%2$s "%3$s" was moved to the trash by %4$s %5$s.', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
 			} elseif ( 'trash' == $old_status ) {
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Restored (from Trash): "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] %2$s Restored (from Trash): "%3$s"', 'vip-workflow' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( '%1$s #%2$s "%3$s" was restored from trash by %4$s %5$s.', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
 			} elseif ( 'future' == $new_status ) {
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Scheduled: "%3$s"' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] %2$s Scheduled: "%3$s"' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email 6. scheduled date  */
 				$body .= sprintf( __( '%1$s #%2$s "%3$s" was scheduled by %4$s %5$s.  It will be published on %6$s' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email, self::get_scheduled_datetime( $post ) ) . "\r\n";
 			} elseif ( 'publish' == $new_status ) {
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Published: "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] %2$s Published: "%3$s"', 'vip-workflow' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( '%1$s #%2$s "%3$s" was published by %4$s %5$s.', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
 			} elseif ( 'publish' == $old_status ) {
 				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Unpublished: "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				$subject = sprintf( __( '[%1$s] %2$s Unpublished: "%3$s"', 'vip-workflow' ), $blogname, $subject_post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( '%1$s #%2$s "%3$s" was unpublished by %4$s %5$s.', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
 			} else {
-				/* translators: 1: site name, 2: post type, 3. post title */
-				$subject = sprintf( __( '[%1$s] %2$s Status Changed for "%3$s"', 'vip-workflow' ), $blogname, $post_type, $post_title );
+				/* translators: 1: site name, 2: post title, 3: post type, 4: new status */
+				$subject = sprintf( __( '[%1$s] "%2$s" %3$s moved to "%4$s"', 'vip-workflow' ), $blogname, $post_title, $subject_post_type, $new_status_friendly_name );
 
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email, 6. old status, 7. new status  */
 				$body .= sprintf( __( 'Status was changed for %1$s #%2$s "%3$s" by %4$s %5$s from "%6$s" to "%7$s".', 'vip-workflow' ), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email, $old_status_friendly_name, $new_status_friendly_name ) . "\r\n";
@@ -174,7 +176,7 @@ class Notifications {
 	 * @param string $message Body of the email
 	 * @param string $message_headers. (optional) Message headers
 	 */
-	public static function schedule_emails( string $action, \WP_Post $post, string $subject, string $message, string $message_headers = '' ): void {
+	public static function schedule_emails( string $action, WP_Post $post, string $subject, string $message, string $message_headers = '' ): void {
 		// Ensure the email address is set from settings.
 		if ( empty( VIP_Workflow::instance()->settings->module->options->email_address ) ) {
 			return;
@@ -305,7 +307,7 @@ class Notifications {
 	* @param WP_Post $post The post object
 	* @return string The formatted date and time that the post is scheduled for
 	*/
-	private static function get_scheduled_datetime( \WP_Post $post ): string {
+	private static function get_scheduled_datetime( WP_Post $post ): string {
 		$scheduled_ts = strtotime( $post->post_date );
 
 		$date = date_i18n( get_option( 'date_format' ), $scheduled_ts );

--- a/modules/shared/php/install-utilities.php
+++ b/modules/shared/php/install-utilities.php
@@ -7,9 +7,6 @@
 
 namespace VIPWorkflow\Modules\Shared\PHP;
 
-use stdClass;
-use VIPWorkflow\VIP_Workflow;
-
 class InstallUtilities {
 	/**
 	 * Given a module name, run a callback function if the module is being run for the first time

--- a/vip-workflow.php
+++ b/vip-workflow.php
@@ -52,5 +52,5 @@ require_once VIP_WORKFLOW_ROOT . '/modules/shared/php/taxonomy-utilities.php';
 
 // Modules
 require_once VIP_WORKFLOW_ROOT . '/modules/editorial-metadata/editorial-metadata.php';
-require_once VIP_WORKFLOW_ROOT . '/modules/preview/preview.php';
 require_once VIP_WORKFLOW_ROOT . '/modules/notifications/notifications.php';
+require_once VIP_WORKFLOW_ROOT . '/modules/preview/preview.php';

--- a/vip-workflow.php
+++ b/vip-workflow.php
@@ -53,3 +53,4 @@ require_once VIP_WORKFLOW_ROOT . '/modules/shared/php/taxonomy-utilities.php';
 // Modules
 require_once VIP_WORKFLOW_ROOT . '/modules/editorial-metadata/editorial-metadata.php';
 require_once VIP_WORKFLOW_ROOT . '/modules/preview/preview.php';
+require_once VIP_WORKFLOW_ROOT . '/modules/notifications/notifications.php';


### PR DESCRIPTION
## Description

I ended up splitting the notifications refactor, and writing up the tests PRs. There'll be another PR that follows this with the tests.

This refactors the notifications module to match what was done for the EM, and preview module. It converts to be isolated, static and adds types to the method definitions.

This also simplifies the webhook scheduling method, so that it can be used for cases beyond just post status updates. An example would be when a status update is rejected, it should be easy to call this method to send a rejection notice. 

I also noticed some previous refactoring items that were missed so I cleaned them up.

## Steps to Test

- Delete the options for notifications, and editorial metadata and ensure the install step is correctly triggered. 
- Ensure when post status changes happen the notifications are correctly sent.
