### PR TITLE
Add tests for notifications

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Static analysis
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,6 +1,9 @@
 name: PHP tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "phpcompatibility/phpcompatibility-wp": "2.1.4",
     "phpunit/phpunit": "9.6.13",
     "yoast/phpunit-polyfills": "2.0.0",
-    "automattic/vipwpcs": "^3.0"
+    "automattic/vipwpcs": "^3.0",
+    "sirbrillig/phpcs-variable-analysis": "^2.11"
   },
   "scripts": {
     "cs": "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*\"",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19aaf03ba52924592ead98bdd544a60c",
+    "content-hash": "4d7dc4ab72013b562eae5e1c4a7862e3",
     "packages": [
         {
             "name": "composer/installers",

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -268,8 +268,9 @@ class Notifications {
 	 * @param string $message Message to be sent to webhook
 	 * @param string $message_type Type of message being sent
 	 * @param string $timestamp Timestamp of the message that corresponds to the time at which the post was updated
+	 * @return bool True if the notification was sent successfully, false otherwise
 	 */
-	public static function send_to_webhook( string $message, string $message_type, string $timestamp ): void {
+	public static function send_to_webhook( string $message, string $message_type, string $timestamp ): bool {
 		$webhook_url = VIP_Workflow::instance()->settings->module->options->webhook_url;
 
 		// Set up the payload
@@ -299,7 +300,10 @@ class Notifications {
 		if ( is_wp_error( $response ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'Unable to send notification to webhook provided.' );
+			return false;
 		}
+
+		return true;
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,7 @@
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="8.0-"/>
 
+	<rule ref="VariableAnalysis"/>
 	<rule ref="WordPress-Extra"/>
 	<rule ref="WordPress-VIP-Go">
 		<!-- These disallow anonymous functions as action callbacks -->

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,5 +41,13 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Add TestCase classes.
 require_once __DIR__ . '/rest-test-case.php';
 
+// Allow wp_mail() in tests from a valid domain name
+tests_add_filter(
+	'wp_mail_from',
+	function () {
+		return 'admin@localhost.test';
+	}
+);
+
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";

--- a/tests/modules/custom-status/test-custom-status-endpoint.php
+++ b/tests/modules/custom-status/test-custom-status-endpoint.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Class RestApiTest
+ * Class CustomStatusRestApiTest
  *
- * @package vip-block-data-api
+ * @package vip-workflow-plugin
  */
 
 namespace VIPWorkflow\Tests;
@@ -11,9 +11,9 @@ use VIPWorkflow\VIP_Workflow;
 use WP_REST_Request;
 
 /**
- * e2e tests to ensure that the REST API endpoint is available.
+ * e2e tests to ensure that the Custom Status REST API endpoint is available.
  */
-class RestApiTest extends RestTestCase {
+class CustomStatusRestApiTest extends RestTestCase {
 
 	/**
 	 * Before each test, ensure default custom statuses are available.

--- a/tests/modules/notifications/test-notifications.php
+++ b/tests/modules/notifications/test-notifications.php
@@ -82,7 +82,7 @@ class NotificationsTest extends WP_UnitTestCase {
 		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
 	}
 
-	public function test_status_change_triggers_notification() {
+	public function test_status_change_triggers_notification_events() {
 		// Hook in and return a known response
 		add_filter( 'pre_http_request', function() {
 			return array(
@@ -107,13 +107,12 @@ class NotificationsTest extends WP_UnitTestCase {
 
 		wp_insert_post( $post );
 
-	    $email = tests_retrieve_phpmailer_instance()->get_sent();
+		$cron_events = reset(_get_cron_array());
 
-		$this->assertNotFalse( $email );
-		$this->assertNotEmpty( $email );
-		$this->assertSame( 1, count( $email->to ) );
+		$this->assertArrayHasKey( 'vw_send_scheduled_emails', $cron_events );
+		$this->assertArrayHasKey( 'vw_send_scheduled_webhook', $cron_events );
 
 		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
-		VIP_Workflow::instance()->settings->module->options->email_address = [];
+		VIP_Workflow::instance()->settings->module->options->email_address = [ ];
 	}
 }

--- a/tests/modules/notifications/test-notifications.php
+++ b/tests/modules/notifications/test-notifications.php
@@ -107,12 +107,10 @@ class NotificationsTest extends WP_UnitTestCase {
 
 		wp_insert_post( $post );
 
+		// Haven't quite been able to get the cron to run in the test environment, so testing if its scheduled or not instead.
 		$cron_events = reset( _get_cron_array() );
 
 		$this->assertArrayHasKey( 'vw_send_scheduled_emails', $cron_events );
 		$this->assertArrayHasKey( 'vw_send_scheduled_webhook', $cron_events );
-
-		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
-		VIP_Workflow::instance()->settings->module->options->email_address = [];
 	}
 }

--- a/tests/modules/notifications/test-notifications.php
+++ b/tests/modules/notifications/test-notifications.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Class NotificationsTest
+ *
+ * @package vip-workflow-plugin
+ */
+
+namespace VIPWorkflow\Tests;
+
+use VIPWorkflow\VIP_Workflow;
+use VIPWorkflow\Modules\Notifications;
+use WP_Error;
+use WP_UnitTestCase;
+
+class NotificationsTest extends WP_UnitTestCase {
+
+	protected function tearDown(): void {
+    	parent::tearDown();
+
+    	reset_phpmailer_instance();
+	}
+
+	public function test_validate_get_notification_footer() {
+		$expected_result = "\r\n--------------------\r\nYou are receiving this email because a notification was configured via the VIP Workflow Plugin.\r\n";
+		$result = Notifications::get_notification_footer();
+
+		$this->assertTrue( $result === $expected_result );
+	}
+
+	public function test_send_emails() {
+		$recipients = [ 'test1@gmail.com', 'test2@gmail.com', 'test3@gmail.com' ];
+		$subject = 'Test Subject';
+		$body = 'Test Body';
+
+		Notifications::send_emails( $recipients, $subject, $body );
+
+		$email = tests_retrieve_phpmailer_instance()->get_sent();
+
+		$this->assertNotFalse( $email );
+		$this->assertNotEmpty( $email );
+		$this->assertSame( 3, count( $email->to ) );
+		$this->assertSame($subject, $email->subject );
+		$this->assertDiscardWhitespace( $body, $email->body );
+	}
+
+	public function test_send_to_webhook_happy_path() {
+		// Hook in and return a known response
+		add_filter( 'pre_http_request', function() {
+			return array(
+				'headers'     => array(),
+				'cookies'     => array(),
+				'filename'    => null,
+				'response'    => 200,
+				'status_code' => 200,
+				'success'     => 1,
+				'body'        => 'All Done',
+			);
+		}, 10, 3 );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = 'https://webhook.site/this-url-doesnt-exist';
+
+		$response = Notifications::send_to_webhook( 'Test Message', 'status-change', '2024-09-19 00:26:50' );
+
+		$this->assertTrue( $response );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
+	}
+
+	public function test_send_to_webhook_error_path() {
+		// Hook in and return a known response
+		add_filter( 'pre_http_request', function() {
+			return new WP_Error( 'http_request_failed', 'Error Message' );
+		}, 10, 3 );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = 'https://webhook.site/this-url-doesnt-exist';
+
+		$response = Notifications::send_to_webhook( 'Test Message', 'status-change', '2024-09-19 00:26:50' );
+
+		$this->assertFalse( $response );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
+	}
+
+	public function test_status_change_triggers_notification() {
+		// Hook in and return a known response
+		add_filter( 'pre_http_request', function() {
+			return array(
+				'headers'     => array(),
+				'cookies'     => array(),
+				'filename'    => null,
+				'response'    => 200,
+				'status_code' => 200,
+				'success'     => 1,
+				'body'        => 'All Done',
+			);
+		}, 10, 3 );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = 'https://webhook.site/this-url-doesnt-exist';
+		VIP_Workflow::instance()->settings->module->options->email_address = [ 'test@gmail.com' ];
+
+		$post = array(
+			'post_content' => rand_str(),
+			'post_title' => rand_str(),
+			'post_date_gmt' => '2024-01-01 12:00:00',
+		);
+
+		wp_insert_post( $post );
+
+	    $email = tests_retrieve_phpmailer_instance()->get_sent();
+
+		$this->assertNotFalse( $email );
+		$this->assertNotEmpty( $email );
+		$this->assertSame( 1, count( $email->to ) );
+
+		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
+		VIP_Workflow::instance()->settings->module->options->email_address = [];
+	}
+}

--- a/tests/modules/notifications/test-notifications.php
+++ b/tests/modules/notifications/test-notifications.php
@@ -16,9 +16,9 @@ use WP_UnitTestCase;
 class NotificationsTest extends WP_UnitTestCase {
 
 	protected function tearDown(): void {
-    	parent::tearDown();
+		parent::tearDown();
 
-    	reset_phpmailer_instance();
+		reset_phpmailer_instance();
 	}
 
 	public function test_validate_get_notification_footer() {
@@ -40,13 +40,13 @@ class NotificationsTest extends WP_UnitTestCase {
 		$this->assertNotFalse( $email );
 		$this->assertNotEmpty( $email );
 		$this->assertSame( 3, count( $email->to ) );
-		$this->assertSame($subject, $email->subject );
+		$this->assertSame( $subject, $email->subject );
 		$this->assertDiscardWhitespace( $body, $email->body );
 	}
 
 	public function test_send_to_webhook_happy_path() {
 		// Hook in and return a known response
-		add_filter( 'pre_http_request', function() {
+		add_filter( 'pre_http_request', function () {
 			return array(
 				'headers'     => array(),
 				'cookies'     => array(),
@@ -69,7 +69,7 @@ class NotificationsTest extends WP_UnitTestCase {
 
 	public function test_send_to_webhook_error_path() {
 		// Hook in and return a known response
-		add_filter( 'pre_http_request', function() {
+		add_filter( 'pre_http_request', function () {
 			return new WP_Error( 'http_request_failed', 'Error Message' );
 		}, 10, 3 );
 
@@ -84,7 +84,7 @@ class NotificationsTest extends WP_UnitTestCase {
 
 	public function test_status_change_triggers_notification_events() {
 		// Hook in and return a known response
-		add_filter( 'pre_http_request', function() {
+		add_filter( 'pre_http_request', function () {
 			return array(
 				'headers'     => array(),
 				'cookies'     => array(),
@@ -107,12 +107,12 @@ class NotificationsTest extends WP_UnitTestCase {
 
 		wp_insert_post( $post );
 
-		$cron_events = reset(_get_cron_array());
+		$cron_events = reset( _get_cron_array() );
 
 		$this->assertArrayHasKey( 'vw_send_scheduled_emails', $cron_events );
 		$this->assertArrayHasKey( 'vw_send_scheduled_webhook', $cron_events );
 
 		VIP_Workflow::instance()->settings->module->options->webhook_url = '';
-		VIP_Workflow::instance()->settings->module->options->email_address = [ ];
+		VIP_Workflow::instance()->settings->module->options->email_address = [];
 	}
 }

--- a/tests/test-class-workflow.php
+++ b/tests/test-class-workflow.php
@@ -1,11 +1,17 @@
 <?php
 
+/**
+ * Class ClassWorkflowTest
+ *
+ * @package vip-workflow-plugin
+ */
+
 namespace VIPWorkflow\Tests;
 
 use VIPWorkflow\VIP_Workflow;
-use PHPUnit\Framework\TestCase;
+use WP_UnitTestCase;
 
-class ClassWorkflowTest extends TestCase {
+class ClassWorkflowTest extends WP_UnitTestCase {
 
 	public function test_validate_vip_workflow_instance_exists() {
 		$this->assertTrue( VIP_Workflow::instance() !== null );


### PR DESCRIPTION
## Description

This PR adds some basic tests for notifications. The only piece that I haven't quite done too well is actually testing if the cron job is picked up or not. So instead, I have tested if the cron jobs get scheduled or not and tested the individual methods instead. That way, the action gets tested as well as the code that it triggers.

I haven't added code coverage in, we can add that in once we have some more tests so we can enforce it.

I also added a variable sniffer rule just in case, and cleaned up a bit of the existing tests.

## Steps to Test

- Run the notification test
