### PR TITLE
Add editorial metadata analytics

### DIFF
--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -371,6 +371,15 @@ class EditorialMetadata {
 
 		$term_result = self::get_editorial_metadata_term_by( 'id', $term_id );
 
+		if ( $term_result ) {
+			/**
+			 * Fires after an editorial metadata field is updated in the database.
+			 *
+			 * @param WP_Term $editorial_metadata The updated editorial metadata WP_Term object.
+			 */
+			do_action( 'vw_update_editorial_metadata_field', $term_result );
+		}
+
 		return $term_result;
 	}
 
@@ -401,7 +410,14 @@ class EditorialMetadata {
 			return new WP_Error( 'invalid', __( 'Unable to delete editorial metadata term.', 'vip-workflow' ) );
 		}
 
-		do_action( 'vw_editorial_metadata_term_deleted', $term_id );
+		/**
+		 * Fires after an editorial metadata field is deleted.
+		 *
+		 * @param int $term_id The ID of the editorial metadata field being deleted
+		 * @param string $term_name The name of the editorial metadata field being deleted
+		 * @param string $term_slug The slug of the editorial metadata field being deleted
+		 */
+		do_action( 'vw_editorial_metadata_term_deleted', $term_id, $term->name, $term->slug );
 
 		return $result;
 	}

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -270,8 +270,8 @@ class EditorialMetadata {
 			return $term;
 		}
 
-		$term_meta = [];
-		$term_meta[ self::METADATA_TYPE_KEY ] = get_term_meta( $term->term_id, self::METADATA_TYPE_KEY, true );
+		$term_meta                                = [];
+		$term_meta[ self::METADATA_TYPE_KEY ]     = get_term_meta( $term->term_id, self::METADATA_TYPE_KEY, true );
 		$term_meta[ self::METADATA_POSTMETA_KEY ] = get_term_meta( $term->term_id, self::METADATA_POSTMETA_KEY, true );
 
 		if ( '' === $term_meta[ self::METADATA_TYPE_KEY ] || '' === $term_meta[ self::METADATA_POSTMETA_KEY ] ) {
@@ -294,7 +294,7 @@ class EditorialMetadata {
 			'slug'        => $args['slug'] ?? sanitize_title( $args['name'] ),
 			'description' => $args['description'] ?? '',
 		];
-		$term_name = $args['name'];
+		$term_name    = $args['name'];
 
 		$inserted_term = wp_insert_term( $term_name, self::METADATA_TAXONOMY, $term_to_save );
 
@@ -304,13 +304,13 @@ class EditorialMetadata {
 
 		$term_id = $inserted_term['term_id'];
 
-		$metadata_type = $args['type'];
-		$metadata_postmeta_key  = self::get_postmeta_key( $metadata_type, $term_id );
+		$metadata_type         = $args['type'];
+		$metadata_postmeta_key = self::get_postmeta_key( $metadata_type, $term_id );
 
 		$type_meta_result = add_term_meta( $term_id, self::METADATA_TYPE_KEY, $metadata_type );
 		if ( is_wp_error( $type_meta_result ) ) {
 			return $type_meta_result;
-		} else if ( ! $type_meta_result ) {
+		} elseif ( ! $type_meta_result ) {
 			// If we can't save the type, we should delete the term
 			wp_delete_term( $term_id, self::METADATA_TAXONOMY );
 			return new WP_Error( 'invalid', __( 'Unable to create editorial metadata.', 'vip-workflow' ) );
@@ -319,7 +319,7 @@ class EditorialMetadata {
 		$postmeta_meta_result = add_term_meta( $term_id, self::METADATA_POSTMETA_KEY, $metadata_postmeta_key );
 		if ( is_wp_error( $postmeta_meta_result ) ) {
 			return $postmeta_meta_result;
-		} else if ( ! $postmeta_meta_result ) {
+		} elseif ( ! $postmeta_meta_result ) {
 			// If we can't save the postmeta key, we should delete the term
 			delete_term_meta( $term_id, self::METADATA_TYPE_KEY );
 			wp_delete_term( $term_id, self::METADATA_TAXONOMY );
@@ -327,6 +327,15 @@ class EditorialMetadata {
 		}
 
 		$term_result = self::get_editorial_metadata_term_by( 'id', $term_id );
+
+		if ( ! is_wp_error( $term_result ) ) {
+			/**
+			 * Fires after a new editorial metadata field is added to the database.
+			 *
+			 * @param WP_Term $term The editorial metadata term object.
+			 */
+			do_action( 'vw_add_editorial_metadata_field', $term_result );
+		}
 
 		return $term_result;
 	}
@@ -342,13 +351,13 @@ class EditorialMetadata {
 		$old_term = self::get_editorial_metadata_term_by( 'id', $term_id );
 		if ( is_wp_error( $old_term ) ) {
 			return $old_term;
-		} else if ( ! $old_term ) {
+		} elseif ( ! $old_term ) {
 			return new WP_Error( 'invalid', __( "Editorial metadata doesn't exist.", 'vip-workflow' ), array( 'status' => 400 ) );
 		}
 
 		$term_fields_to_update = [
-			'name'    => isset( $args['name'] ) ? $args['name'] : $old_term->name,
-			'slug'    => isset( $args['slug'] ) ? $args['slug'] : $old_term->slug,
+			'name'        => isset( $args['name'] ) ? $args['name'] : $old_term->name,
+			'slug'        => isset( $args['slug'] ) ? $args['slug'] : $old_term->slug,
 			'description' => isset( $args['description'] ) ? $args['description'] : $old_term->description,
 		];
 
@@ -375,7 +384,7 @@ class EditorialMetadata {
 		$term = self::get_editorial_metadata_term_by( 'id', $term_id );
 		if ( is_wp_error( $term ) ) {
 			return $term;
-		} else if ( ! $term ) {
+		} elseif ( ! $term ) {
 			return new WP_Error( 'invalid', __( "Editorial metadata term doesn't exist.", 'vip-workflow' ), array( 'status' => 400 ) );
 		}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -398,7 +398,8 @@ class EditorialMetadata {
 		}
 
 		// Delete the post meta for the term
-		$post_meta_key = self::get_postmeta_key( $term->meta[ self::METADATA_TYPE_KEY ], $term_id );
+		$metadata_type = $term->meta[ self::METADATA_TYPE_KEY ];
+		$post_meta_key = self::get_postmeta_key( $metadata_type, $term_id );
 		delete_post_meta_by_key( $post_meta_key );
 
 		delete_term_meta( $term_id, self::METADATA_TYPE_KEY );
@@ -416,8 +417,9 @@ class EditorialMetadata {
 		 * @param int $term_id The ID of the editorial metadata field being deleted
 		 * @param string $term_name The name of the editorial metadata field being deleted
 		 * @param string $term_slug The slug of the editorial metadata field being deleted
+		 * @param string $metadata_type The type of field, e.g. 'date', 'text'
 		 */
-		do_action( 'vw_editorial_metadata_term_deleted', $term_id, $term->name, $term->slug );
+		do_action( 'vw_editorial_metadata_term_deleted', $term_id, $term->name, $term->slug, $metadata_type );
 
 		return $result;
 	}

--- a/modules/telemetry/telemetry.php
+++ b/modules/telemetry/telemetry.php
@@ -4,6 +4,7 @@ namespace VIPWorkflow\Modules\Telemetry;
 
 use Automattic\VIP\Telemetry\Tracks;
 use VIPWorkflow\Modules\CustomStatus;
+use VIPWorkflow\Modules\EditorialMetadata;
 use VIPWorkflow\Modules\Shared\PHP\HelperUtilities;
 use WP_Post;
 use WP_Term;
@@ -34,6 +35,9 @@ class Telemetry {
 		// Settings events
 		add_action( 'vw_upgrade_version', [ __CLASS__, 'record_admin_update' ], 10, 2 );
 		add_action( 'vw_save_settings', [ __CLASS__, 'record_settings_update' ], 10, 2 );
+
+		// Editorial Metadata events
+		add_action( 'vw_add_editorial_metadata_field', [ __CLASS__, 'record_add_editorial_metadata_field' ], 10, 1 );
 	}
 
 	// Custom Status events
@@ -240,6 +244,22 @@ class Telemetry {
 		} else {
 			self::$tracks->record_event( 'send_to_email_enabled' );
 		}
+	}
+
+	// Editorial Metadata events
+
+	/**
+	 * Record an event when an editorial metadata field is added
+	 *
+	 * @param WP_Term $editorial_metadata The name of the field
+	 */
+	public static function record_add_editorial_metadata_field( WP_Term $editorial_metadata ): void {
+		self::$tracks->record_event( 'em_field_created', [
+			'term_id' => $editorial_metadata->term_id,
+			'name'    => $editorial_metadata->name,
+			'slug'    => $editorial_metadata->slug,
+			'type'    => $editorial_metadata->meta[ EditorialMetadata::METADATA_TYPE_KEY ],
+		] );
 	}
 }
 

--- a/modules/telemetry/telemetry.php
+++ b/modules/telemetry/telemetry.php
@@ -26,8 +26,8 @@ class Telemetry {
 		// Custom Status events
 		add_action( 'transition_post_status', [ __CLASS__, 'record_custom_status_change' ], 10, 3 );
 		add_action( 'vw_add_custom_status', [ __CLASS__, 'record_add_custom_status' ], 10, 3 );
-		add_action( 'vw_delete_custom_status', [ __CLASS__, 'record_delete_custom_status' ], 10, 3 );
 		add_action( 'vw_update_custom_status', [ __CLASS__, 'record_update_custom_status' ], 10, 2 );
+		add_action( 'vw_delete_custom_status', [ __CLASS__, 'record_delete_custom_status' ], 10, 3 );
 
 		// Notification events
 		add_action( 'vw_notification_status_change', [ __CLASS__, 'record_notification_sent' ], 10, 3 );
@@ -38,6 +38,8 @@ class Telemetry {
 
 		// Editorial Metadata events
 		add_action( 'vw_add_editorial_metadata_field', [ __CLASS__, 'record_add_editorial_metadata_field' ], 10, 1 );
+		add_action( 'vw_update_editorial_metadata_field', [ __CLASS__, 'record_update_editorial_metadata_field' ], 10, 1 );
+		add_action( 'vw_editorial_metadata_term_deleted', [ __CLASS__, 'record_delete_editorial_metadata_field' ], 10, 3 );
 	}
 
 	// Custom Status events
@@ -259,6 +261,36 @@ class Telemetry {
 			'name'    => $editorial_metadata->name,
 			'slug'    => $editorial_metadata->slug,
 			'type'    => $editorial_metadata->meta[ EditorialMetadata::METADATA_TYPE_KEY ],
+		] );
+	}
+
+	/**
+	 * Record an event when an editorial metadata field is updated
+	 *
+	 * @param WP_Term $updated_status The updated status WP_Term object.
+	 * @param array $update_args The arguments used to update the status.
+	 */
+	public static function record_update_editorial_metadata_field( WP_Term $editorial_metadata ): void {
+		self::$tracks->record_event( 'em_field_changed', [
+			'term_id' => $editorial_metadata->term_id,
+			'name'    => $editorial_metadata->name,
+			'slug'    => $editorial_metadata->slug,
+			'type'    => $editorial_metadata->meta[ EditorialMetadata::METADATA_TYPE_KEY ],
+		] );
+	}
+
+	/**
+	 * Record an event when an editorial metadata field is deleted
+	 *
+	 * @param int $term_id The editorial metadata field term ID
+	 * @param string $term_name The editorial metadata name
+	 * @param string $slug The editorial metadata slug
+	 */
+	public static function record_delete_editorial_metadata_field( int $term_id, string $term_name, string $slug ): void {
+		self::$tracks->record_event( 'em_field_deleted', [
+			'term_id' => $term_id,
+			'name'    => $term_name,
+			'slug'    => $slug,
 		] );
 	}
 }

--- a/modules/telemetry/telemetry.php
+++ b/modules/telemetry/telemetry.php
@@ -77,9 +77,12 @@ class Telemetry {
 		] );
 
 		if ( 'publish' === $new_status ) {
+			$em_field_counts = self::get_em_field_counts_for_post( $post->ID );
+
 			self::$tracks->record_event( 'post_custom_status_published', [
 				'post_id'          => $post->ID,
-				'em_fields_filled' => self::get_filled_em_fields_for_post( $post->ID ),
+				'em_fields_filled' => $em_field_counts['filled'],
+				'em_fields_total'  => $em_field_counts['total'],
 			] );
 		}
 	}
@@ -309,9 +312,11 @@ class Telemetry {
 	 * Get the number of filled editorial metadata fields for a post
 	 *
 	 * @param int $post_id The post ID
-	 * @return int The number of fields with a value set
+	 * @return array An associative array with keys:
+	 *     int 'filled_count': The number of filled fields
+	 *     int 'total_count': The total number of EM fields available
 	 */
-	private static function get_filled_em_fields_for_post( int $post_id ): int {
+	private static function get_em_field_counts_for_post( int $post_id ): array {
 		$editorial_metadata_terms = EditorialMetadata::get_editorial_metadata_terms();
 		$filled_em_fields         = 0;
 
@@ -324,7 +329,10 @@ class Telemetry {
 			}
 		}
 
-		return $filled_em_fields;
+		return [
+			'filled' => $filled_em_fields,
+			'total'  => count( $editorial_metadata_terms ),
+		];
 	}
 }
 


### PR DESCRIPTION
## Description

This adds some VIP-only telemetry for editorial metadata fields:

- `em_field_created`, with data:
  - `int term_id`
  - `string name`
  - `string slug`
  - `string type` (e.g. `text`/`checkbox`)
- `em_field_changed`, with data (same as above):
  - `int term_id`
  - `string name`
  - `string slug`
  - `string type` (e.g. `text`/`checkbox`)
- `em_field_deleted`, with data (same as above):
  - `int term_id`
  - `string name`
  - `string slug`
  - `string type` (e.g. `text`/`checkbox`)

Additionally in https://github.com/Automattic/vip-workflow-plugin/pull/21 we also record these data related to EM fields:

- In [`record_add_custom_status()`](https://github.com/Automattic/vip-workflow-plugin/blob/ac24ea36c4bb2bed43dcc0619ae6506b0654fd01/modules/telemetry/telemetry.php#L74-L91), which fires when a new custom status field is created, we record the number of users and number of required EM fields associated with that custom status.

- In [`record_update_custom_status()`](https://github.com/Automattic/vip-workflow-plugin/blob/ac24ea36c4bb2bed43dcc0619ae6506b0654fd01/modules/telemetry/telemetry.php#L114-L131), which fires each time a custom status is edited in the Workflow editor, we record the number of users and number of required EM fields associated with that custom status.

Between these two sets of data, we should be able to see if folks are doing CRUD operations on EM fields as well as how many are being used in the required functionality of custom statuses.

