### PR TITLE
Fix PHP 8 fatal error when editing unsupported post type in block editor

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -268,8 +268,15 @@ class CustomStatus {
 
 		$custom_statuses = self::get_custom_statuses();
 
-		// Add the required editorial metadata to the custom statuses for UI purposes
+		// Add the required editorial metadata to the custom statuses for UI purposes.
+		// When the current post type is unsupported, get_custom_statuses() returns the result of
+		// get_core_statuses(), which are plain arrays rather than WP_Term objects. Skip those since
+		// they carry no editorial metadata, and attempting object property access on an array is a
+		// fatal error in PHP 8.
 		foreach ( $custom_statuses as $status ) {
+			if ( ! is_object( $status ) ) {
+				continue;
+			}
 			$required_metadata_ids = $status->meta[ self::METADATA_REQ_EDITORIAL_IDS_KEY ] ?? [];
 			$required_metadatas    = [];
 			foreach ( $required_metadata_ids as $metadata_id ) {


### PR DESCRIPTION
## Problem

When creating or editing a post of a post type that is **not registered with VIP Workflow**, the block editor throws a PHP 8 fatal error:

```
PHP Fatal error: Uncaught Error: Attempt to modify property "meta" on array
in modules/custom-status/custom-status.php:278
```

**Stack trace:**
```
CustomStatus::modify_custom_statuses_with_editorial_metadata()
CustomStatus::load_scripts_for_block_editor()
WP_Hook->apply_filters()
do_action('enqueue_block_editor_assets')
```

## Root Cause

`get_custom_statuses()` correctly detects that the post type is unsupported and falls back to `get_core_statuses()`. However, `get_core_statuses()` returns plain associative arrays, while `modify_custom_statuses_with_editorial_metadata()` assumes every item is a `WP_Term` object and writes to `$status->meta[...]`. PHP 8 treats this as a fatal error.

## Fix

Add an `is_object()` guard in the loop inside `modify_custom_statuses_with_editorial_metadata()` to skip non-object items. Core status arrays carry no editorial metadata so skipping them is semantically correct — no behaviour change for supported post types.

## Testing

1. Register a post type that is **not** added to VIP Workflow's supported post types.
2. Navigate to **New Post** for that post type in the block editor.
3. Before this fix: PHP fatal error, white screen.
4. After this fix: block editor loads normally.