### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       actions-major:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "major"
+          - 'major'
     cooldown:
       default-days: 7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,12 +41,12 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.2'
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress
 

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -41,13 +41,13 @@ jobs:
         run: npm -g install @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress
 


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 4
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# ramsey/composer-install # 3.2.1 -> a8d0d959dab41457692a5e2041bd9b757a119e3f
gh api repos/ramsey/composer-install/commits/3.2.1 --jq '.sha'
# expected: a8d0d959dab41457692a5e2041bd9b757a119e3f

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
